### PR TITLE
Refactor modal handling: consolidate modal open/close logic

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -78,15 +78,6 @@ function renderCartItems() {
     });
 }
 
-cartBtn.addEventListener('click', () => {
-    cartModal.style.display = 'block';
-    renderCartItems();
-});
-
-closeCart.addEventListener('click', () => {
-    cartModal.style.display = 'none';
-});
-
 document.querySelector('.checkout-btn').addEventListener('click', () => {
 
     if (cart.length === 0) {
@@ -98,8 +89,18 @@ document.querySelector('.checkout-btn').addEventListener('click', () => {
     checkoutModal.style.display = 'block';
 });
 
-closeCheckout.addEventListener('click', () => {
-    checkoutModal.style.display = 'none';
+document.querySelectorAll('.open-modal').forEach(button => {
+    button.addEventListener('click', (event) => {
+        const modalId = event.target.dataset.modalId;
+        const modal = document.getElementById(modalId);
+        modal.style.display = 'block';
+    });
+});
+
+document.querySelectorAll('.close-modal').forEach(button => {
+    button.addEventListener('click', () => {
+        button.closest('.modal').style.display = 'none';
+    });
 });
 
 window.addEventListener('click', (event) => {


### PR DESCRIPTION
Змінив логіку відкриття та закриття модальних вікон, об'єднавши їх в одну функцію, щоб уникнути дублювання коду. Раніше для кожного модального вікна були окремі обробники подій, що ускладнювало підтримку. Тепер для всіх кнопок закриття використовується один обробник подій із загальним класом .close-modal, що дозволяє закривати будь-яке модальне вікно, просто додавши відповідний клас до кнопки закриття і це спрощує код і робить його зручнішим для майбутніх змін!