### PR TITLE
duplication correction in inner HTML in updateCart()

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -39,7 +39,6 @@ function updateCart() {
     cartItemsContainer.innerHTML = '';
     let total = 0;
 
-    cartItemsContainer.innerHTML = '';
     cart.forEach((item, index) => {
         const itemDiv = document.createElement('div');
         itemDiv.className = 'cart-item';


### PR DESCRIPTION
Problem: The function updateCart()is cleaning the container twice due to repeated pcartItemsContainer.innerHTML = '', which is redundant and can affect performance, especially
Decision:
Delete duplicate row, by
Consider using the document.createElement()and methods appendChild()to dynamically create and add elements.