### PR TITLE
Refactor: Use data-attributes for product prices

### DIFF
--- a/Script.js
+++ b/Script.js
@@ -600,18 +600,18 @@ function createShopItem(item) {
         <h3>${item.name} <span class="item-category">(${item.category})</span></h3>
         <p>${item.description}</p>
         <p class="price">$${item.price}</p>
-        <button class="buy-btn">Купити</button>
+        <button class="buy-btn" data-price="${item.price}" data-name="${item.name}">Купити</button>
     `;
     return shopItem;
 }
 
 document.getElementById('shopGrid').addEventListener('click', (e) => {
     if (e.target.classList.contains('buy-btn')) {
-        currentItemName = e.target.parentElement.querySelector('h3').textContent;
-        currentItemPrice = parseFloat(e.target.parentElement.querySelector('.price').textContent.replace('$', ''));
+        // Новий, надійний код:
+        currentItemName = e.target.dataset.name; 
+        currentItemPrice = parseFloat(e.target.dataset.price);
 
         confirmMessage.textContent = `Ви підтверджуєте додавання "${currentItemName}" до кошика?`;
-
         confirmModal.style.display = 'flex';
     }
 });


### PR DESCRIPTION
I have updated the product rendering and "add to cart" logic to use data attributes instead of parsing HTML text.

**Changes:**
- Updated `createShopItem` function to add `data-price="${item.price}"` and `data-name="${item.name}"` to the "Buy" button.
- Refactored the event listener in `Script.js` to read` e.target.dataset.price` and `e.target.dataset.name`.
- Removed the fragile `.replace('$', '')` logic.